### PR TITLE
feat: add pagination warning if deployments >=100

### DIFF
--- a/modules/deployment_cleanup.sh
+++ b/modules/deployment_cleanup.sh
@@ -58,7 +58,7 @@ run_deployment_cleanup() {
         # Check if deployments exist
         if [ -z "$DEPLOYMENTS_JSON" ] || [ "$DEPLOYMENTS_JSON" = "null" ]; then
             echo
-            gum style --padding "1 2" --border normal --border-foreground "#f8e45c" \
+            gum style --padding "1 2" --border normal --border-foreground "$COLOR_BLUE" \
                 "No deployments found in the '$ENV_NAME' environment." \
                 "Please select a different environment."
             echo
@@ -106,7 +106,7 @@ run_deployment_cleanup() {
             continue
         fi
         
-        # If we have deployments, break out of the loop
+        # If deployments exist, break out of the loop
         break
     done
 


### PR DESCRIPTION
If you have 100 or more deployments, there will now be a warning that informs them that there might be more deployments than what's being shown. Github's `--paginate` flag should handle this, but just in case.

## What's changed?
- **Too many deployments**:
  - A yellow warning will appear if there are over 100 deployments and that users should make sure all deployments are loaded.

## Follow-up
- Better error messages instead of just cryptic warnings or just the program outright exiting. This will be centered around the Github API (rate limit, permissions, etc.).