### PR TITLE
refactor: replace selection menu with keyboard shortcuts

### DIFF
--- a/modules/deployment_cleanup.sh
+++ b/modules/deployment_cleanup.sh
@@ -25,7 +25,7 @@ run_deployment_cleanup() {
         fi
     done
 
-    # --- 2: Select an environment (with loop for retry) ---
+    # --- 2: Select an environment ---
     while true; do
         local get_envs_cmd="gh api 'repos/$REPO_NAME/environments' --jq '.environments.[].name' 2>/dev/null || true"
         
@@ -57,137 +57,64 @@ run_deployment_cleanup() {
         
         # Check if deployments exist
         if [ -z "$DEPLOYMENTS_JSON" ] || [ "$DEPLOYMENTS_JSON" = "null" ]; then
-            echo
             gum style --padding "1 2" --border normal --border-foreground "$COLOR_BLUE" \
                 "No deployments found in the '$ENV_NAME' environment." \
                 "Please select a different environment."
-            echo
             
             if ! gum confirm "Would you like to choose a different environment?" \
-                --prompt.bold \
-                --prompt.foreground "" \
+                --prompt.foreground "$COLOR_BLUE" \
                 --selected.background "$COLOR_BLUE" \
                 --selected.foreground "#FFFFFF"; then
                 clear
                 return
             fi
-            
             clear
             # Loop continues, allowing user to select another environment
             continue
         fi
         
-        # Extract IDs for counting and deletion
-        local DEPLOYMENT_IDS
-        DEPLOYMENT_IDS=$(echo "$DEPLOYMENTS_JSON" | jq -r '.id' | grep -v '^$')
-        
-        local DEPLOYMENT_COUNT
-        DEPLOYMENT_COUNT=$(echo "$DEPLOYMENT_IDS" | wc -l | xargs)
-
-        # If DEPLOYMENT_IDS is empty or just whitespace, treat as no deployments
-        if [ -z "$(echo "$DEPLOYMENT_IDS" | xargs)" ]; then
-            echo
-            gum style --padding "1 2" --border normal --border-foreground "#f8e45c" \
-                "No deployments found in the '$ENV_NAME' environment." \
-                "Please select a different environment."
-            echo
-            
-            if ! gum confirm "Would you like to choose a different environment?" \
-                --prompt.bold \
-                --prompt.foreground "" \
-                --selected.background "$COLOR_BLUE" \
-                --selected.foreground "#FFFFFF"; then
-                clear
-                return
-            fi
-            
-            clear
-            # Loop continues, allowing user to select another environment
-            continue
+        # Check deployment count (simple check before parsing list)
+        local RAW_IDS
+        RAW_IDS=$(echo "$DEPLOYMENTS_JSON" | jq -r '.id')
+        if [ -z "$RAW_IDS" ]; then
+             gum style --foreground "$COLOR_RED" "Error parsing deployments."
+             return
         fi
         
-        # If deployments exist, break out of the loop
-        break
+        break # Exit the environment selection loop
     done
 
-    # --- 3.5: Show deployments ---
+    # --- 4: Select Deployments to Delete ---
     echo
-    gum style --bold --foreground "$COLOR_GREEN" "Found $DEPLOYMENT_COUNT deployment(s) in '$ENV_NAME':"
-    
-    # Warn if pagination limits is reached
-    if [ "$DEPLOYMENT_COUNT" -ge 100 ]; then
-        echo
-        gum style --foreground "#f8e45c" "⚠ Note: There are 100+ deployments. Make sure all are loaded."
-    fi
-    
+    gum style --bold "Select deployments to delete:"
+    gum style --foreground "$COLOR_BORDER" "(Space to select, 'a' to select all, Enter to confirm)"
     echo
     
-    # Display in a nice table format
-    echo "$DEPLOYMENTS_JSON" | jq -r '"  ID: \(.id) | Creator: \(.creator) | Created: \(.created)"'
-    echo
-
-    # --- 4: Show action menu ---
-    local action
-    action=$(gum choose \
-        "Delete ALL deployments" \
-        "Delete specific deployments (select)" \
-        "Cancel" \
-        --header "What would you like to do?" \
-        --header.bold \
-        --header.foreground "" \
+    # Create formatted list for selection: [ID] Creator - Date
+    local deployment_options
+    deployment_options=$(echo "$DEPLOYMENTS_JSON" | jq -r '"[\(.id)] \(.creator) - \(.created)"')
+    
+    local selected_deployments
+    selected_deployments=$(echo "$deployment_options" | gum choose --no-limit --height 15 \
         --cursor.foreground "$COLOR_BLUE" \
         --selected.foreground "$COLOR_BLUE")
     
-    if [ "$action" = "Cancel" ]; then
+    if [ -z "$selected_deployments" ]; then
+        gum style --foreground "$COLOR_BLUE" "No deployments selected."
+        sleep 2
         clear
         return
     fi
     
-    # --- 5: Handle selection (if selective deletion) ---
-    local SELECTED_IDS="$DEPLOYMENT_IDS"
-    local SELECTED_COUNT="$DEPLOYMENT_COUNT"
-    
-    if [ "$action" = "Delete specific deployments (select)" ]; then
-        echo
-        gum style --bold "Select deployments to delete (use Space to select, Enter to confirm):"
-        echo
-        
-        # Create formatted list for selection
-        local deployment_options
-        deployment_options=$(echo "$DEPLOYMENTS_JSON" | jq -r '"[\(.id)] \(.creator) - \(.created)"')
-        
-        if [ -z "$deployment_options" ]; then
-            gum style --foreground "$COLOR_RED" "Error creating selection list."
-            sleep 2
-            clear
-            return
-        fi
-        
-        # Let user select multiple deployments
-        local selected_deployments
-        selected_deployments=$(echo "$deployment_options" | gum choose --no-limit \
-            --cursor.foreground "$COLOR_BLUE" \
-            --selected.foreground "$COLOR_BLUE")
-        
-        if [ -z "$selected_deployments" ]; then
-            gum style --foreground "$COLOR_BLUE" "No deployments selected."
-            sleep 2
-            clear
-            return
-        fi
-        
-        # Get IDs from selected items
-        SELECTED_IDS=$(echo "$selected_deployments" | sed 's/^\[\([0-9]*\)\].*/\1/')
-        SELECTED_COUNT=$(echo "$SELECTED_IDS" | grep -c . || echo "0")
-        
-        echo
-        gum style --foreground "$COLOR_GREEN" "Selected $SELECTED_COUNT deployment(s) for deletion."
-        sleep 1
-    fi
+    # Get IDs from selected items
+    local SELECTED_IDS
+    SELECTED_IDS=$(echo "$selected_deployments" | sed 's/^\[\([0-9]*\)\].*/\1/')
+    local SELECTED_COUNT
+    SELECTED_COUNT=$(echo "$SELECTED_IDS" | grep -c . || echo "0")
 
-    # --- 6: CONFIRM DELETION ---
+    # --- 5: CONFIRM DELETION ---
     echo
-    if ! gum confirm "You are about to PERMANENTLY delete ${SELECTED_COUNT} deployment(s) from the \"${ENV_NAME}\" environment. Proceed?" \
+    if ! gum confirm "You are about to PERMANENTLY delete ${SELECTED_COUNT} deployment(s) from \"${ENV_NAME}\". Proceed?" \
         --prompt.bold \
         --prompt.foreground "" \
         --selected.background "$COLOR_BLUE" \
@@ -196,13 +123,11 @@ run_deployment_cleanup() {
         return
     fi
 
-    # --- 7: Deletion loop ---
+    # --- 6: Deletion loop ---
     clear
     gum style --bold --foreground "$COLOR_BLUE" -- "--- Starting Deletion Process ---"
     echo
 
-    # !!! Temporarily disable 'set -e' for this section
-    # Or else the program will just exit out!
     set +e
     
     local i=0
@@ -211,7 +136,6 @@ run_deployment_cleanup() {
     while IFS= read -r id; do
         # Skip empty lines
         [ -z "$id" ] && continue
-        
         # Skip if id is just whitespace
         id=$(echo "$id" | xargs)
         [ -z "$id" ] && continue
@@ -227,12 +151,10 @@ run_deployment_cleanup() {
             echo "  $(gum style --foreground "$COLOR_GREEN" "✔") Successfully deleted."
             ((deleted_count++))
         else
-            # If fails, mark as inactive first
-            echo "  $(gum style --foreground "#f8e45c" "…") Active deployment. Marking as 'inactive' first..."
+            # Mark inactive then delete
+            echo "  $(gum style --foreground "#f8e45c" "…") Active deployment. Marking 'inactive'..."
             gh api --method POST "repos/$REPO_NAME/deployments/$id/statuses" \
-                -f state='inactive' \
-                -f description='Decommissioning for cleanup' \
-                --silent 2>/dev/null
+                -f state='inactive' -f description='Cleanup' --silent 2>/dev/null
             
             # Try deleting again
             gh api --method DELETE "repos/$REPO_NAME/deployments/$id" --silent 2>/dev/null
@@ -242,7 +164,7 @@ run_deployment_cleanup() {
                  echo "  $(gum style --foreground "$COLOR_GREEN" "✔") Successfully deleted."
                  ((deleted_count++))
             else
-                 echo "  $(gum style --foreground "$COLOR_RED" "✖") FAILED to delete deployment ID: $id."
+                 echo "  $(gum style --foreground "$COLOR_RED" "✖") FAILED to delete ID: $id."
             fi
         fi
     done <<< "$SELECTED_IDS"
@@ -253,11 +175,10 @@ run_deployment_cleanup() {
     echo
     local line1="✨ Process Complete! ✨"
     local line2
-    line2=$(gum style --foreground "$COLOR_GREEN" "Deleted ${deleted_count} of ${SELECTED_COUNT} deployments from the '${ENV_NAME}' environment.")
+    line2=$(gum style --foreground "$COLOR_GREEN" "Deleted ${deleted_count} of ${SELECTED_COUNT} deployments from '${ENV_NAME}'.")
     
     gum style --padding "1 2" --border normal --border-foreground "$COLOR_GREEN" \
-        "$line1" \
-        "$line2"
+        "$line1" "$line2"
 
     echo
     echo "(Press any key to return to the main menu.)"


### PR DESCRIPTION
Updated the deployment cleanup module to be more efficient by removing unnecessary menus.

## What's changed?

- **No more selection menu**:
  - Removed the intermediate menu that asked users to choose between "delete all" and "selective deletion"
  - The module now goes straight to the deployment selection list
  - Users can use `ctrl + a` to select all deployments at once or 'Space' for specific ones.
  - Added a small instruction label to the selection screen to clarify these keybindings

---

> Closes #7 - Replaced "what would you like to do" menu prior to selection with keyboard shortcuts