### PR TITLE
fix: silent crash when `gum` is missing from dependency checker

### DIFF
--- a/gh-helper.sh
+++ b/gh-helper.sh
@@ -36,8 +36,8 @@ check_dependencies() {
     done
 
     if [ ${#missing_deps[@]} -gt 0 ]; then
-        gum style --border normal --border-foreground "$COLOR_RED" --padding "1 2" \
-            "Warning: Required tools are missing: ${missing_deps[*]}"
+        if [ ${#missing_deps[@]} -gt 0 ]; then
+            echo "Warning: Required tools are missing: ${missing_deps[*]}" # Changed to `echo` -- in case `gum` is missing
 
         if gum confirm "Would you like to try and install them now?" \
             --prompt.foreground "$COLOR_BLUE" \


### PR DESCRIPTION
If `gum` was one of the missing dependencies, the checker would immediately call `gum style` to display the warning, crashing before it could prompt the user to install anything.

## What's changed?

- **`gh-helper.sh` — `check_dependencies`**
  - Replaced `gum style` warning with plain `echo` for the initial missing-deps notice

---

> Closes #16 - replaced `gum style` with `echo` so the warning displays even when `gum` isn't installed yet