### PR TITLE
fix: `local` keyword masking exit codes in `branch_pruning.sh`

### DIFF
--- a/modules/branch_pruning.sh
+++ b/modules/branch_pruning.sh
@@ -114,9 +114,12 @@ run_branch_pruning() {
         fi
     done
 
-    local current_epoch=$(date +%s)
-    local threshold_seconds=$((THRESHOLD_DAYS * 86400))
-    local cutoff_epoch=$((current_epoch - threshold_seconds))
+    local current_epoch
+    local threshold_seconds
+    local cutoff_epoch
+    current_epoch=$(date +%s)
+    threshold_seconds=$((THRESHOLD_DAYS * 86400))
+    cutoff_epoch=$((current_epoch - threshold_seconds))
 
     # --- 4: Fetch data & calculate staleness ---
     echo


### PR DESCRIPTION
Declaring and assigning `local` variables on the same line causes `local` to always return exit code 0, masking any failure in the command substitution on the right-hand side.

## What's changed?

- **`modules/branch_pruning.sh`**
  - Split `local current_epoch`, `local threshold_seconds`, and `local cutoff_epoch` declarations onto their own lines, with assignments following separately

---

> Closes #18 - separated `local` declarations from assignments so command substitution exit codes are no longer suppressed