### PR TITLE
feat: add "Back" option to module mode selectors

### DIFF
--- a/modules/branch_pruning.sh
+++ b/modules/branch_pruning.sh
@@ -48,13 +48,14 @@ run_branch_pruning() {
         ACCOUNT_TYPE=$(gum choose \
             "Personal Account" \
             "Organization" \
+            "Back" \
             --header "Fetch repositories from:" \
             --header.bold \
             --header.foreground "" \
             --cursor.foreground "$COLOR_BLUE" \
             --selected.foreground "$COLOR_BLUE")
         
-        if [ -z "$ACCOUNT_TYPE" ]; then clear; return; fi
+        if [ "$ACCOUNT_TYPE" = "Back" ] || [ -z "$ACCOUNT_TYPE" ]; then clear; return; fi
 
         local REPOS_JSON
         if [ "$ACCOUNT_TYPE" = "Organization" ]; then

--- a/modules/branch_pruning.sh
+++ b/modules/branch_pruning.sh
@@ -13,14 +13,14 @@ run_branch_pruning() {
     MODE=$(gum choose \
         "Single Repository" \
         "Multiple Repositories" \
-        "Cancel" \
+        "Back" \
         --header "Prune branches in:" \
         --header.bold \
         --header.foreground "" \
         --cursor.foreground "$COLOR_BLUE" \
         --selected.foreground "$COLOR_BLUE")
 
-    if [ "$MODE" = "Cancel" ] || [ -z "$MODE" ]; then clear; return; fi
+    if [ "$MODE" = "Back" ] || [ -z "$MODE" ]; then clear; return; fi
 
     local SELECTED_REPOS=""
 

--- a/modules/deployment_cleanup.sh
+++ b/modules/deployment_cleanup.sh
@@ -40,14 +40,14 @@ run_deployment_cleanup() {
         fi
 
         local ENV_NAME
-        ENV_NAME=$(echo "$ENV_NAMES" | gum choose \
+        ENV_NAME=$(echo -e "$ENV_NAMES\nBack" | gum choose \
             --header "Select an environment to clean" \
             --header.bold \
             --header.foreground "" \
             --cursor.foreground "$COLOR_BLUE" \
             --selected.foreground "$COLOR_BLUE")
 
-        if [ -z "$ENV_NAME" ]; then clear; return; fi
+        if [ "$ENV_NAME" = "Back" ] || [ -z "$ENV_NAME" ]; then clear; return; fi
 
         # --- 3: Get deployments ---
         local get_deployments_cmd="gh api 'repos/$REPO_NAME/deployments?per_page=100' --paginate --jq '.[] | select(.environment == \"$ENV_NAME\") | {id: .id, env: .environment, creator: .creator.login, created: .created_at}' 2>/dev/null || true"


### PR DESCRIPTION
Several `gum choose` prompts had no clean exit path. Previously, users were stuck completing the flow or waiting for the end-of-module "press any key" screen. This adds a consistent "Back" option across all affected selectors.

## What's changed?

- **`modules/branch_pruning.sh`**
  - Renamed "Cancel" to "Back" in the Single/Multiple repository chooser for consistency
  - Added "Back" to the Personal Account/Organization chooser, which previously had no exit option
  - 
- **`modules/deployment_cleanup.sh`**
  - Added "Back" to the environment selector by appending it to the dynamic options list

---

> Closes #24 - added "Back" option to all mode selectors that lacked a clean exit path