### PR TITLE
style: add repo context to confirmation dialogs across all modules

### DIFF
--- a/modules/actions_cache.sh
+++ b/modules/actions_cache.sh
@@ -79,7 +79,7 @@ run_actions_cache() {
 
     # --- 5: Confirmation ---
     echo
-    if ! gum confirm "You are about to delete $COUNT cache(s). This cannot be undone. Proceed?" \
+    if ! gum confirm "You are about to delete $COUNT cache(s) from '$REPO_NAME'. This cannot be undone. Proceed?" \
         --prompt.bold \
         --prompt.foreground "" \
         --selected.background "$COLOR_BLUE" \

--- a/modules/branch_pruning.sh
+++ b/modules/branch_pruning.sh
@@ -193,7 +193,7 @@ EOF
 
     # --- 6: Confirm deletion ---
     echo
-    if ! gum confirm "You are about to PERMANENTLY delete $COUNT branch(es). Proceed?" \
+    if ! gum confirm "You are about to PERMANENTLY delete $COUNT branch(es) across the selected repos. Proceed?" \
         --prompt.bold \
         --prompt.foreground "" \
         --selected.background "$COLOR_BLUE" \

--- a/modules/deployment_cleanup.sh
+++ b/modules/deployment_cleanup.sh
@@ -114,7 +114,7 @@ run_deployment_cleanup() {
 
     # --- 5: CONFIRM DELETION ---
     echo
-    if ! gum confirm "You are about to PERMANENTLY delete ${SELECTED_COUNT} deployment(s) from \"${ENV_NAME}\". Proceed?" \
+    if ! gum confirm "You are about to PERMANENTLY delete ${SELECTED_COUNT} deployment(s) from '${REPO_NAME}/${ENV_NAME}'. Proceed?" \
         --prompt.bold \
         --prompt.foreground "" \
         --selected.background "$COLOR_BLUE" \

--- a/modules/workflow_cleanup.sh
+++ b/modules/workflow_cleanup.sh
@@ -69,7 +69,7 @@ run_workflow_cleanup() {
 
     # --- 4: Confirmation ---
     echo
-    if ! gum confirm "Are you sure you want to PERMANENTLY delete these $COUNT runs?" \
+    if ! gum confirm "Are you sure you want to PERMANENTLY delete these $COUNT runs from '$REPO_NAME'?" \
         --prompt.bold \
         --prompt.foreground "" \
         --selected.background "$COLOR_BLUE" \


### PR DESCRIPTION
Confirmation prompts didn't remind users which repo they were operating on, making it easy to lose track of context by the time the destructive step was reached.

## What's changed?

- **`modules/actions_cache.sh`**
  - Added `'$REPO_NAME'` to the cache deletion confirmation prompt
- **`modules/workflow_cleanup.sh`**
  - Added `'$REPO_NAME'` to the workflow run deletion confirmation prompt
- **`modules/branch_pruning.sh`**
  - Updated confirmation to note deletion is across selected repos rather than a single named repo
- **`modules/deployment_cleanup.sh`**
  - Updated confirmation to include both `'$REPO_NAME'` and `'$ENV_NAME'` in the format `repo/environment`

---

> Closes #34 - added repo name to all confirmation dialogs so users always know what context they're deleting from