### PR TITLE
fix: suppress default "Choose:" header on piped `gum choose` calls

### DIFF
--- a/modules/actions_cache.sh
+++ b/modules/actions_cache.sh
@@ -60,6 +60,7 @@ run_actions_cache() {
 
     local selected_lines
     selected_lines=$(echo "$formatted_list" | gum choose --no-limit --height 15 \
+        --header "" \
         --cursor.foreground "$COLOR_BLUE" \
         --selected.foreground "$COLOR_BLUE")
 

--- a/modules/branch_pruning.sh
+++ b/modules/branch_pruning.sh
@@ -86,6 +86,7 @@ run_branch_pruning() {
         echo
         
         SELECTED_REPOS=$(echo "$REPOS_JSON" | gum choose --no-limit --height 15 \
+            --header "" \
             --cursor.foreground "$COLOR_BLUE" \
             --selected.foreground "$COLOR_BLUE")
         

--- a/modules/branch_pruning.sh
+++ b/modules/branch_pruning.sh
@@ -175,6 +175,7 @@ EOF
 
     local selected_lines
     selected_lines=$(echo "$formatted_list" | gum choose --no-limit --height 15 \
+        --header "" \
         --cursor.foreground "$COLOR_BLUE" \
         --selected.foreground "$COLOR_BLUE")
 

--- a/modules/deployment_cleanup.sh
+++ b/modules/deployment_cleanup.sh
@@ -96,6 +96,7 @@ run_deployment_cleanup() {
     
     local selected_deployments
     selected_deployments=$(echo "$deployment_options" | gum choose --no-limit --height 15 \
+        --header "" \
         --cursor.foreground "$COLOR_BLUE" \
         --selected.foreground "$COLOR_BLUE")
     

--- a/modules/workflow_cleanup.sh
+++ b/modules/workflow_cleanup.sh
@@ -51,6 +51,7 @@ run_workflow_cleanup() {
 
     local selected_lines
     selected_lines=$(echo "$formatted_list" | gum choose --no-limit --height 15 \
+        --header "" \
         --cursor.foreground "$COLOR_BLUE" \
         --selected.foreground "$COLOR_BLUE")
 


### PR DESCRIPTION
When `gum choose` receives options via a pipe, it displays a default purple "Choose:" prompt above the list. Since all modules already print a `gum style --bold` header before the chooser, this was redundant and visually inconsistent.

## What's changed?

- **`modules/actions_cache.sh`**
  - Added `--header ""` to the cache selection `gum choose` call
  
- **`modules/workflow_cleanup.sh`**
  - Added `--header ""` to the run selection `gum choose` call

- **`modules/deployment_cleanup.sh`**
  - Added `--header ""` to the deployment selection `gum choose` call

- **`modules/branch_pruning.sh`**
  - Added `--header ""` to the stale branch selection `gum choose` call
  - Added `--header ""` to the multi-repo selection `gum choose` call

---

> Closes #30 - added `--header ""` to all piped `gum choose` calls to suppress the default purple prompt