### PR TITLE
style: add repo context to success screens

### DIFF
--- a/modules/actions_cache.sh
+++ b/modules/actions_cache.sh
@@ -129,7 +129,7 @@ run_actions_cache() {
     echo
     local line1="✨ Process Complete! ✨"
     local line2
-    line2=$(gum style --foreground "$COLOR_GREEN" "Deleted $deleted_count of $COUNT caches.")
+    line2=$(gum style --foreground "$COLOR_GREEN" "Deleted $deleted_count of $COUNT caches from '$REPO_NAME'.")
 
     gum style --padding "1 2" --border normal --border-foreground "$COLOR_GREEN" \
         "$line1" \

--- a/modules/branch_pruning.sh
+++ b/modules/branch_pruning.sh
@@ -237,9 +237,11 @@ EOF
     local line1="✨ Process Complete! ✨"
     local line2
     line2=$(gum style --foreground "$COLOR_GREEN" "Deleted $deleted_count of $COUNT stale branches.")
+    local line3
+    line3=$(gum style --foreground "$COLOR_BORDER" "across the selected repos.")
 
     gum style --padding "1 2" --border normal --border-foreground "$COLOR_GREEN" \
-        "$line1" "$line2"
+        "$line1" "$line2" "$line3"
 
     echo
     echo "(Press any key to return to the main menu.)"

--- a/modules/deployment_cleanup.sh
+++ b/modules/deployment_cleanup.sh
@@ -176,7 +176,7 @@ run_deployment_cleanup() {
     echo
     local line1="✨ Process Complete! ✨"
     local line2
-    line2=$(gum style --foreground "$COLOR_GREEN" "Deleted ${deleted_count} of ${SELECTED_COUNT} deployments from '${ENV_NAME}'.")
+    line2=$(gum style --foreground "$COLOR_GREEN" "Deleted ${deleted_count} of ${SELECTED_COUNT} deployments from '${REPO_NAME}/${ENV_NAME}'.")
     
     gum style --padding "1 2" --border normal --border-foreground "$COLOR_GREEN" \
         "$line1" "$line2"


### PR DESCRIPTION
Success screens only reported a count (e.g. "Deleted 3 of 5 caches") with no reminder of which repo was operated on. This closes #31. success screens are updated now, and the main menu subtitle will follow in #32 once session-scoped repo context is available.

## What's changed?

- **`modules/actions_cache.sh`**
  - Added `'$REPO_NAME'` to the success screen summary line
- **`modules/branch_pruning.sh`**
  - Added "across the selected repos." as a third line on the success screen since branch pruning operates on multiple repos
- **`modules/deployment_cleanup.sh`**
  - Updated success screen to show `'$REPO_NAME/$ENV_NAME'` instead of just `'$ENV_NAME'`
- **`modules/workflow_cleanup.sh`**
  - No change needed — already included repo name in success screen

---

> Closes #31 - success screens updated with repo context; main menu subtitle pending #32