### PR TITLE
Style/descriptive success screens

### DIFF
--- a/modules/actions_cache.sh
+++ b/modules/actions_cache.sh
@@ -99,7 +99,9 @@ run_actions_cache() {
 
     local i=0
     local deleted_count=0
-    
+    local deleted_keys=""
+    local failed_ids=""
+
     # Read IDs line by line
     while IFS= read -r id; do
         # Skip empty lines
@@ -108,6 +110,11 @@ run_actions_cache() {
         [ -z "$id" ] && continue
 
         ((i++))
+
+        # Look up the key for this ID from the original selection
+        local cache_key
+        cache_key=$(echo "$selected_lines" | grep "^\[$id\]" | sed "s/^\[$id\] \([^ ]*\).*/\1/")
+
         echo "$(gum style --foreground "$COLOR_BLUE" "•") Deleting cache $i of $COUNT (ID: $id)..."
         
         # Try to delete
@@ -117,8 +124,10 @@ run_actions_cache() {
         if [ $delete_result -eq 0 ]; then
             echo "  $(gum style --foreground "$COLOR_GREEN" "✔") Successfully deleted."
             ((deleted_count++))
+            deleted_keys="${deleted_keys}\n  $(gum style --foreground "$COLOR_GREEN" "✔") ${cache_key}"
         else
             echo "  $(gum style --foreground "$COLOR_RED" "✖") Failed to delete ID: $id"
+            failed_ids="${failed_ids}\n  $(gum style --foreground "$COLOR_RED" "✖") ID: $id"
         fi
     done <<< "$SELECTED_IDS"
 
@@ -134,6 +143,18 @@ run_actions_cache() {
     gum style --padding "1 2" --border normal --border-foreground "$COLOR_GREEN" \
         "$line1" \
         "$line2"
+
+    if [ -n "$deleted_keys" ]; then
+        echo
+        gum style --bold "Deleted:"
+        echo -e "$deleted_keys"
+    fi
+
+    if [ -n "$failed_ids" ]; then
+        echo
+        gum style --bold --foreground "$COLOR_RED" "Failed:"
+        echo -e "$failed_ids"
+    fi
 
     echo
     echo "(Press any key to return to the main menu.)"

--- a/modules/branch_pruning.sh
+++ b/modules/branch_pruning.sh
@@ -210,8 +210,11 @@ EOF
     echo
 
     set +e
+    
     local i=0
     local deleted_count=0
+    local deleted_branches=""
+    local failed_branches=""
 
     while IFS= read -r target; do
         [ -z "$target" ] && continue
@@ -226,8 +229,10 @@ EOF
         if gh api --method DELETE "repos/$repo_name/git/refs/heads/$branch_name" --silent 2>/dev/null; then
             echo "  $(gum style --foreground "$COLOR_GREEN" "✔") Successfully deleted."
             ((deleted_count++))
+            deleted_branches="${deleted_branches}\n  $(gum style --foreground "$COLOR_GREEN" "✔") ${repo_name}:${branch_name}"
         else
             echo "  $(gum style --foreground "$COLOR_RED" "✖") Failed to delete branch."
+            failed_branches="${failed_branches}\n  $(gum style --foreground "$COLOR_RED" "✖") ${repo_name}:${branch_name}"
         fi
     done <<< "$TARGETS"
     set -e
@@ -242,6 +247,18 @@ EOF
 
     gum style --padding "1 2" --border normal --border-foreground "$COLOR_GREEN" \
         "$line1" "$line2" "$line3"
+
+    if [ -n "$deleted_branches" ]; then
+        echo
+        gum style --bold "Deleted:"
+        echo -e "$deleted_branches"
+    fi
+
+    if [ -n "$failed_branches" ]; then
+        echo
+        gum style --bold --foreground "$COLOR_RED" "Failed:"
+        echo -e "$failed_branches"
+    fi
 
     echo
     echo "(Press any key to return to the main menu.)"

--- a/modules/deployment_cleanup.sh
+++ b/modules/deployment_cleanup.sh
@@ -133,15 +133,20 @@ run_deployment_cleanup() {
     
     local i=0
     local deleted_count=0
-    
+    local deleted_deployments=""
+    local failed_ids=""
+
     while IFS= read -r id; do
-        # Skip empty lines
         [ -z "$id" ] && continue
-        # Skip if id is just whitespace
         id=$(echo "$id" | xargs)
         [ -z "$id" ] && continue
 
         ((i++))
+
+        # Look up the ref + sha for this ID from the original selection
+        local deploy_label
+        deploy_label=$(echo "$selected_deployments" | grep "^\[$id\]" | sed "s/^\[$id\] //")
+
         echo "$(gum style --foreground "$COLOR_BLUE" "•") Processing deployment $i of $SELECTED_COUNT (ID: $id)..."
 
         # Try to delete directly first
@@ -151,6 +156,7 @@ run_deployment_cleanup() {
         if [ $delete_result -eq 0 ]; then
             echo "  $(gum style --foreground "$COLOR_GREEN" "✔") Successfully deleted."
             ((deleted_count++))
+            deleted_deployments="${deleted_deployments}\n  $(gum style --foreground "$COLOR_GREEN" "✔") ${deploy_label}"
         else
             # Mark inactive then delete
             echo "  $(gum style --foreground "#f8e45c" "…") Active deployment. Marking 'inactive'..."
@@ -162,10 +168,12 @@ run_deployment_cleanup() {
             delete_result=$?
             
             if [ $delete_result -eq 0 ]; then
-                 echo "  $(gum style --foreground "$COLOR_GREEN" "✔") Successfully deleted."
-                 ((deleted_count++))
+                echo "  $(gum style --foreground "$COLOR_GREEN" "✔") Successfully deleted."
+                ((deleted_count++))
+                deleted_deployments="${deleted_deployments}\n  $(gum style --foreground "$COLOR_GREEN" "✔") ${deploy_label}"
             else
-                 echo "  $(gum style --foreground "$COLOR_RED" "✖") FAILED to delete ID: $id."
+                echo "  $(gum style --foreground "$COLOR_RED" "✖") FAILED to delete ID: $id."
+                failed_ids="${failed_ids}\n  $(gum style --foreground "$COLOR_RED" "✖") ID: $id"
             fi
         fi
     done <<< "$SELECTED_IDS"
@@ -180,6 +188,18 @@ run_deployment_cleanup() {
     
     gum style --padding "1 2" --border normal --border-foreground "$COLOR_GREEN" \
         "$line1" "$line2"
+
+    if [ -n "$deleted_deployments" ]; then
+        echo
+        gum style --bold "Deleted:"
+        echo -e "$deleted_deployments"
+    fi
+
+    if [ -n "$failed_ids" ]; then
+        echo
+        gum style --bold --foreground "$COLOR_RED" "Failed:"
+        echo -e "$failed_ids"
+    fi
 
     echo
     echo "(Press any key to return to the main menu.)"

--- a/modules/workflow_cleanup.sh
+++ b/modules/workflow_cleanup.sh
@@ -85,21 +85,31 @@ run_workflow_cleanup() {
     echo
 
     set +e
+    
     local i=0
     local deleted_count=0
-    
+    local deleted_runs=""
+    local failed_ids=""
+
     while IFS= read -r id; do
         [ -z "$id" ] && continue
         id=$(echo "$id" | xargs)
         [ -z "$id" ] && continue
 
         ((i++))
+
+        # Look up the run name for this ID from the original selection
+        local run_name
+        run_name=$(echo "$selected_lines" | grep "^\[$id\]" | sed "s/^\[$id\] \(.*\) ([a-z]*) -.*/\1/")
+
         echo "$(gum style --foreground "$COLOR_BLUE" "•") Deleting run $i of $COUNT (ID: $id)..."
         
         if gh api --method DELETE "repos/$REPO_NAME/actions/runs/$id" --silent 2>/dev/null; then
             ((deleted_count++))
+            deleted_runs="${deleted_runs}\n  $(gum style --foreground "$COLOR_GREEN" "✔") ${run_name} (${id})"
         else
             echo "  $(gum style --foreground "$COLOR_RED" "✖") Failed to delete ID: $id"
+            failed_ids="${failed_ids}\n  $(gum style --foreground "$COLOR_RED" "✖") ID: $id"
         fi
     done <<< "$RUN_IDS"
     set -e
@@ -108,11 +118,23 @@ run_workflow_cleanup() {
     echo
     local line1="✨ Process Complete! ✨"
     local line2
-    line2=$(gum style --foreground "$COLOR_GREEN" "Successfully deleted $deleted_count workflow runs from '$REPO_NAME'.")
+    line2=$(gum style --foreground "$COLOR_GREEN" "Successfully deleted $deleted_count of $COUNT workflow runs from '$REPO_NAME'.")
 
     gum style --padding "1 2" --border normal --border-foreground "$COLOR_GREEN" \
         "$line1" \
         "$line2"
+
+    if [ -n "$deleted_runs" ]; then
+        echo
+        gum style --bold "Deleted:"
+        echo -e "$deleted_runs"
+    fi
+
+    if [ -n "$failed_ids" ]; then
+        echo
+        gum style --bold --foreground "$COLOR_RED" "Failed:"
+        echo -e "$failed_ids"
+    fi
 
     echo
     echo "(Press any key to return to the main menu.)"


### PR DESCRIPTION
# feat: add detailed deleted/failed lists to success screens

Success screens previously only reported a count. All modules now display exactly which items were deleted and which failed, derived from the existing selection data with no extra API calls.

## What's changed?

- **`modules/actions_cache.sh`**
  - Tracks deleted cache keys and failed IDs during the deletion loop
  - Displays a "Deleted:" list and optional "Failed:" list below the summary box

- **`modules/workflow_cleanup.sh`**
  - Tracks deleted run names + IDs and failed IDs during the deletion loop
  - Displays a "Deleted:" list and optional "Failed:" list below the summary box

- **`modules/branch_pruning.sh`**
  - Tracks deleted and failed branches in `repo:branch` format during the deletion loop
  - Displays a "Deleted:" list and optional "Failed:" list below the summary box

- **`modules/deployment_cleanup.sh`**
  - Tracks deleted deployment labels (creator • ref • sha - date) and failed IDs during the deletion loop
  - Displays a "Deleted:" list and optional "Failed:" list below the summary box
  - Handles both direct-delete and inactive-then-delete paths correctly

---

> Closes #33 - all modules now list deleted and failed items individually on the success screen