### PR TITLE
feat: add session-scoped default repository prompt

### DIFF
--- a/gh-helper.sh
+++ b/gh-helper.sh
@@ -149,12 +149,20 @@ display_main_menu() {
     local header_text
     header_text=$(gum style --bold --foreground "$COLOR_BLUE" "What would you like to do?")
 
+    # Show active repo as subtitle if set
+    if [ -n "$DEFAULT_REPO" ]; then
+        local repo_text
+        repo_text=$(gum style --foreground "$COLOR_BORDER" "Active repo: $DEFAULT_REPO")
+        echo "$repo_text"
+    fi
+
     local choice
     choice=$(gum choose \
         "Deployment Cleanup" \
         "Actions Cache Management" \
         "Bulk Workflow Run Cleanup" \
         "Stale Branch Pruning" \
+        "Change Repository" \
         "Quit" \
         --height 10 \
         --header "$header_text" \
@@ -173,6 +181,9 @@ display_main_menu() {
             ;;
         "Stale Branch Pruning")
             run_branch_pruning
+            ;;
+        "Change Repository")
+            change_repo
             ;;
         "Quit")
             gum style --foreground "$COLOR_GREEN" "Goodbye!"

--- a/gh-helper.sh
+++ b/gh-helper.sh
@@ -23,6 +23,10 @@ source "$SCRIPT_DIR/modules/actions_cache.sh"
 source "$SCRIPT_DIR/modules/workflow_cleanup.sh"
 source "$SCRIPT_DIR/modules/branch_pruning.sh"
 
+# --- Session state ---
+# Global default repo for this session. Empty if not set.
+DEFAULT_REPO=""
+
 # --- Dependency checker ---
 # Checks for required tools and offers to install them if missing.
 check_dependencies() {
@@ -85,6 +89,61 @@ display_welcome() {
     echo ""
 }
 
+# --- Default repo prompt ---
+# Runs once on launch. Sets the global DEFAULT_REPO for the session.
+prompt_default_repo() {
+    echo
+    local input
+    input=$(gum input \
+        --placeholder "owner/repo (or press Enter to skip)" \
+        --prompt "Enter a default repository for this session: " \
+        --prompt.bold \
+        --cursor.foreground "$COLOR_BLUE")
+
+    # User skipped — no default repo this session
+    if [ -z "$input" ]; then
+        return
+    fi
+
+    # Validate the repo
+    if gh repo view "$input" &>/dev/null; then
+        DEFAULT_REPO="$input"
+        gum style --foreground "$COLOR_GREEN" "✔ Default repo set to '$DEFAULT_REPO'."
+        echo
+    else
+        gum style --foreground "$COLOR_RED" "Repository '$input' not found or you don't have access. No default set."
+        echo
+    fi
+}
+
+# --- Change repo ---
+# Re-prompts for a default repo. Called from the main menu.
+change_repo() {
+    echo
+    local input
+    input=$(gum input \
+        --placeholder "owner/repo (or press Enter to clear)" \
+        --prompt "Enter a new default repository: " \
+        --prompt.bold \
+        --cursor.foreground "$COLOR_BLUE")
+
+    if [ -z "$input" ]; then
+        DEFAULT_REPO=""
+        gum style --foreground "$COLOR_BLUE" "Default repo cleared."
+        echo
+        return
+    fi
+
+    if gh repo view "$input" &>/dev/null; then
+        DEFAULT_REPO="$input"
+        gum style --foreground "$COLOR_GREEN" "✔ Default repo updated to '$DEFAULT_REPO'."
+        echo
+    else
+        gum style --foreground "$COLOR_RED" "Repository '$input' not found or you don't have access. Default repo unchanged."
+        echo
+    fi
+}
+
 # --- Main menu ---
 display_main_menu() {
     local header_text
@@ -123,14 +182,12 @@ display_main_menu() {
 }
 
 # --- Main ---
-#
 #   1. Clears the screen first
 #   2. Checks if all required tools are installed
 #   3. Checks if the user is authenticated with gh
 #       3.5. If not, => `gh auth login`
 #   4. Once logged in, show welcome screen
 #   5. Loop the main menu until user quits
-#
 main() {
     clear 
     
@@ -152,6 +209,7 @@ main() {
     fi
 
     display_welcome
+    prompt_default_repo
 
     while true; do
         display_main_menu

--- a/modules/actions_cache.sh
+++ b/modules/actions_cache.sh
@@ -10,20 +10,27 @@ run_actions_cache() {
 
     # --- 1: Get the repo ---
     local REPO_NAME
-    while true; do
-        REPO_NAME=$(gum input --placeholder "owner/repo" \
-            --prompt.bold \
-            --prompt "Enter the repository: " \
-            --cursor.foreground "$COLOR_BLUE")
+    if [ -n "$DEFAULT_REPO" ]; then
+        # Use the session default, show a confirmation line
+        REPO_NAME="$DEFAULT_REPO"
+        gum style --foreground "$COLOR_BORDER" "Working on: $REPO_NAME"
+        echo
+    else
+        while true; do
+            REPO_NAME=$(gum input --placeholder "owner/repo" \
+                --prompt.bold \
+                --prompt "Enter the repository: " \
+                --cursor.foreground "$COLOR_BLUE")
 
-        if [ -z "$REPO_NAME" ]; then clear; return; fi
+            if [ -z "$REPO_NAME" ]; then clear; return; fi
 
-        if gh repo view "$REPO_NAME" &>/dev/null; then
-            break
-        else
-            gum style --foreground "$COLOR_RED" "Error: Repository '$REPO_NAME' not found or you don't have access."
-        fi
-    done
+            if gh repo view "$REPO_NAME" &>/dev/null; then
+                break
+            else
+                gum style --foreground "$COLOR_RED" "Error: Repository '$REPO_NAME' not found or you don't have access."
+            fi
+        done
+    fi
 
     # --- 2: Fetch Caches ---
     # Fetch ID, Key, Size, and Last Accessed time.

--- a/modules/branch_pruning.sh
+++ b/modules/branch_pruning.sh
@@ -26,22 +26,29 @@ run_branch_pruning() {
 
     # --- 2: Get repo(s) ---
     if [ "$MODE" = "Single Repository" ]; then
-        while true; do
-            local REPO_NAME
-            REPO_NAME=$(gum input --placeholder "owner/repo" \
-                --prompt.bold \
-                --prompt "Enter the repository: " \
-                --cursor.foreground "$COLOR_BLUE")
+        if [ -n "$DEFAULT_REPO" ]; then
+            # Use the session default, show a confirmation line
+            gum style --foreground "$COLOR_BORDER" "Working on: $DEFAULT_REPO"
+            echo
+            SELECTED_REPOS="$DEFAULT_REPO"
+        else
+            while true; do
+                local REPO_NAME
+                REPO_NAME=$(gum input --placeholder "owner/repo" \
+                    --prompt.bold \
+                    --prompt "Enter the repository: " \
+                    --cursor.foreground "$COLOR_BLUE")
 
-            if [ -z "$REPO_NAME" ]; then clear; return; fi
+                if [ -z "$REPO_NAME" ]; then clear; return; fi
 
-            if gh repo view "$REPO_NAME" &>/dev/null; then
-                SELECTED_REPOS="$REPO_NAME"
-                break
-            else
-                gum style --foreground "$COLOR_RED" "Error: Repository '$REPO_NAME' not found or you don't have access."
-            fi
-        done
+                if gh repo view "$REPO_NAME" &>/dev/null; then
+                    SELECTED_REPOS="$REPO_NAME"
+                    break
+                else
+                    gum style --foreground "$COLOR_RED" "Error: Repository '$REPO_NAME' not found or you don't have access."
+                fi
+            done
+        fi
     else
         # Multiple repositories flow
         local ACCOUNT_TYPE

--- a/modules/deployment_cleanup.sh
+++ b/modules/deployment_cleanup.sh
@@ -10,20 +10,27 @@ run_deployment_cleanup() {
 
     # --- 1: Get the repo ---
     local REPO_NAME
-    while true; do
-        REPO_NAME=$(gum input --placeholder "owner/repo" \
-            --prompt.bold \
-            --prompt "Enter the repository to clean: " \
-            --cursor.foreground "$COLOR_BLUE")
+    if [ -n "$DEFAULT_REPO" ]; then
+        # Use the session default, show a confirmation line
+        REPO_NAME="$DEFAULT_REPO"
+        gum style --foreground "$COLOR_BORDER" "Working on: $REPO_NAME"
+        echo
+    else
+        while true; do
+            REPO_NAME=$(gum input --placeholder "owner/repo" \
+                --prompt.bold \
+                --prompt "Enter the repository to clean: " \
+                --cursor.foreground "$COLOR_BLUE")
 
-        if [ -z "$REPO_NAME" ]; then clear; return; fi
+            if [ -z "$REPO_NAME" ]; then clear; return; fi
 
-        if gh repo view "$REPO_NAME" &>/dev/null; then
-            break
-        else
-            gum style --foreground "$COLOR_RED" "Error: Repository '$REPO_NAME' not found or you don't have access. Please try again."
-        fi
-    done
+            if gh repo view "$REPO_NAME" &>/dev/null; then
+                break
+            else
+                gum style --foreground "$COLOR_RED" "Error: Repository '$REPO_NAME' not found or you don't have access. Please try again."
+            fi
+        done
+    fi
 
     # --- 2: Select an environment ---
     while true; do

--- a/modules/workflow_cleanup.sh
+++ b/modules/workflow_cleanup.sh
@@ -10,20 +10,27 @@ run_workflow_cleanup() {
 
     # --- 1: Get the repo ---
     local REPO_NAME
-    while true; do
-        REPO_NAME=$(gum input --placeholder "owner/repo" \
-            --prompt.bold \
-            --prompt "Enter the repository: " \
-            --cursor.foreground "$COLOR_BLUE")
+    if [ -n "$DEFAULT_REPO" ]; then
+        # Use the session default, show a confirmation line
+        REPO_NAME="$DEFAULT_REPO"
+        gum style --foreground "$COLOR_BORDER" "Working on: $REPO_NAME"
+        echo
+    else
+        while true; do
+            REPO_NAME=$(gum input --placeholder "owner/repo" \
+                --prompt.bold \
+                --prompt "Enter the repository: " \
+                --cursor.foreground "$COLOR_BLUE")
 
-        if [ -z "$REPO_NAME" ]; then clear; return; fi
+            if [ -z "$REPO_NAME" ]; then clear; return; fi
 
-        if gh repo view "$REPO_NAME" &>/dev/null; then
-            break
-        else
-            gum style --foreground "$COLOR_RED" "Error: Repository '$REPO_NAME' not found or you don't have access."
-        fi
-    done
+            if gh repo view "$REPO_NAME" &>/dev/null; then
+                break
+            else
+                gum style --foreground "$COLOR_RED" "Error: Repository '$REPO_NAME' not found or you don't have access."
+            fi
+        done
+    fi
 
     # --- 2: Fetch and Filter Runs ---
     # Single fetch for all required fields: ID, name, conclusion, and date.


### PR DESCRIPTION
Each module previously asked for a repo independently, making it repetitive when working across multiple modules in one session. A default repo set at launch now carries through the session, with a dedicated main menu option to change it at any time.

## What's changed?

- **`gh-helper.sh`**
  - Added `DEFAULT_REPO` global session variable
  - Added `prompt_default_repo()` — runs once on launch, validates and stores the default repo
  - Added `change_repo()` — re-prompts and updates `DEFAULT_REPO`, called from the main menu
  - Main menu now shows `Active repo: owner/repo` subtitle when a default is set
  - Added "Change Repository" option to the main menu above "Quit"

- **`modules/actions_cache.sh`, `modules/workflow_cleanup.sh`, `modules/deployment_cleanup.sh`**
  - Skips repo input prompt and shows `Working on: owner/repo` when `DEFAULT_REPO` is set

- **`modules/branch_pruning.sh`**
  - Pre-fills `SELECTED_REPOS` from `DEFAULT_REPO` in the single-repo flow when set
  - Multi-repo flow is unaffected

---

> Closes #32 - added session-scoped default repo prompt on launch with Change Repository option on main menu